### PR TITLE
Refactor return URL handling in auth modal

### DIFF
--- a/wp-content/themes/trek-travel-theme/assets/js/developer.js
+++ b/wp-content/themes/trek-travel-theme/assets/js/developer.js
@@ -6156,7 +6156,7 @@ jQuery(document).on('lity:open', function (event, instance) {
     document.body.classList.add('lity-login-modal');
 
     if (returnUrl) {
-      jQuery('#login-form input[name="http_referer"]').val(returnUrl);
+      jQuery('#login-register-modal input[name="http_referer"]').val(returnUrl);
     }
   }
 });

--- a/wp-content/themes/trek-travel-theme/assets/js/tt-global-common.js
+++ b/wp-content/themes/trek-travel-theme/assets/js/tt-global-common.js
@@ -8,10 +8,10 @@ document.addEventListener('DOMContentLoaded', function () {
 		if (instance.opener().attr('href') === '#login-register-modal') {
 			document.body.classList.add('lity-login-modal');
 
-			if (returnUrl) {
-				jQuery('#login-form input[name="http_referer"]').val(returnUrl);
-			}
-		}
+                        if (returnUrl) {
+                                jQuery('#login-register-modal input[name="http_referer"]').val(returnUrl);
+                        }
+                }
 	});
 
 	jQuery(document).on('lity:close', function () {

--- a/wp-content/themes/trek-travel-theme/inc/trek-shortcodes.php
+++ b/wp-content/themes/trek-travel-theme/inc/trek-shortcodes.php
@@ -22,8 +22,19 @@
                      <p class="my-1">Sign up to personalize your experience and trips.</p>
                </div>
 
-                 <form method="post" class="woocommerce-form woocommerce-form-register needs-validation" novalidate <?php do_action('woocommerce_register_form_tag'); ?>>
-                     <?php do_action('woocommerce_register_form_start'); ?>
+                <?php
+                    $http_referer = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
+                    $ref_sourceUrl = parse_url($http_referer);
+                    $site_urlParse = parse_url(site_url());
+                    $redirect_url = site_url('my-account');
+                    if( $ref_sourceUrl && isset($ref_sourceUrl['host']) &&
+                       $site_urlParse && isset($site_urlParse['host']) &&
+                       $ref_sourceUrl['host'] == $site_urlParse['host'] ){
+                        $redirect_url = $http_referer;
+                    }
+                ?>
+                <form id="register-form" method="post" class="woocommerce-form woocommerce-form-register needs-validation" novalidate <?php do_action('woocommerce_register_form_tag'); ?>>
+                    <?php do_action('woocommerce_register_form_start'); ?>
  
                      <div class="field-group my-auto">
  
@@ -73,6 +84,7 @@
                          <button type="submit" class="btn btn-bb" name="register">
                              <?php esc_html_e('Sign up', 'trek-travel-theme'); ?>
                          </button>
+                         <input type="hidden" name="http_referer" value="<?php echo esc_url( $redirect_url ); ?>">
                      </div>
                      <?php do_action('woocommerce_register_form_end'); ?>
                  </form>


### PR DESCRIPTION
## Summary
- handle register form HTTP referer like login form
- update JavaScript to set referer on all auth modal forms

## Testing
- `php -l wp-content/themes/trek-travel-theme/inc/trek-shortcodes.php`
- `node --check wp-content/themes/trek-travel-theme/assets/js/developer.js`
- `node --check wp-content/themes/trek-travel-theme/assets/js/tt-global-common.js`


------
https://chatgpt.com/codex/tasks/task_e_6855a1a53b788322a87c492db841b672