### PR TITLE
Handle return URL in registration flow

### DIFF
--- a/wp-content/themes/trek-travel-theme/assets/js/tt-global-common.js
+++ b/wp-content/themes/trek-travel-theme/assets/js/tt-global-common.js
@@ -1,18 +1,19 @@
 document.addEventListener('DOMContentLoaded', function () {
     console.log('Trek Travel Theme Global Common JS Loaded');
-	// Inject return URL into login form
-	jQuery(document).on('lity:open', function (event, instance) {
-		const $opener = instance.opener();
-		const returnUrl = $opener.data('return-url');
+        // Inject return URL into login and registration form
+        jQuery(document).on('lity:open', function (event, instance) {
+                const $opener = instance.opener();
+                const returnUrl = $opener.data('return-url');
 
-		if (instance.opener().attr('href') === '#login-register-modal') {
-			document.body.classList.add('lity-login-modal');
+                if (instance.opener().attr('href') === '#login-register-modal') {
+                        document.body.classList.add('lity-login-modal');
 
-			if (returnUrl) {
-				jQuery('#login-form input[name="http_referer"]').val(returnUrl);
-			}
-		}
-	});
+                        if (returnUrl) {
+                                jQuery('#login-form input[name="http_referer"]').val(returnUrl);
+                                jQuery('#login-register-modal .woocommerce-form-register input[name="http_referer"]').val(returnUrl);
+                        }
+                }
+        });
 
 	jQuery(document).on('lity:close', function () {
 		document.body.classList.remove('lity-login-modal');

--- a/wp-content/themes/trek-travel-theme/functions.php
+++ b/wp-content/themes/trek-travel-theme/functions.php
@@ -967,9 +967,20 @@ function custom_address_update_message_and_redirect( $user_id, $load_address ) {
  *
  * @param int $user_id The ID of the newly registered user.
  */
-add_filter( 'woocommerce_registration_redirect', function($redirect){
-	$redirect = home_url( '/register-success/' );
-	return $redirect;
+add_filter( 'woocommerce_registration_redirect', function( $redirect ) {
+        $redirect = home_url( '/register-success/' );
+
+        if ( isset( $_POST['http_referer'] ) ) {
+                $referer      = esc_url_raw( wp_unslash( $_POST['http_referer'] ) );
+                $ref_source   = parse_url( $referer );
+                $site_url     = parse_url( site_url() );
+
+                if ( $ref_source && $site_url && isset( $ref_source['host'] ) && isset( $site_url['host'] ) && $ref_source['host'] === $site_url['host'] ) {
+                        $redirect = $referer;
+                }
+        }
+
+        return $redirect;
 });
 //chnaged password metered strenght
  function iconic_min_password_strength( $strength ) {

--- a/wp-content/themes/trek-travel-theme/inc/trek-shortcodes.php
+++ b/wp-content/themes/trek-travel-theme/inc/trek-shortcodes.php
@@ -12,8 +12,10 @@
      update_option('woocommerce_registration_generate_password', 'no');
      if (is_admin() || is_user_logged_in()) return;
  
-     do_action('woocommerce_before_customer_login_form');
-     $google_api_key = G_CAPTCHA_SITEKEY ?: '6LfNqogpAAAAAEoQ66tbnh01t0o_2YXgHVSde0zV';
+    do_action('woocommerce_before_customer_login_form');
+    global $wp;
+    $current_url = home_url(add_query_arg([], $wp->request));
+    $google_api_key = G_CAPTCHA_SITEKEY ?: '6LfNqogpAAAAAEoQ66tbnh01t0o_2YXgHVSe0zV';
      ?>
       <div class="row">
              <div class="col-12 login-form">
@@ -61,7 +63,8 @@
                         <input type="text" name="tt-ba" style="display:none;" tabindex="-1" autocomplete="off" />
 
                         <input type="hidden" name="form_start_time" value="<?php echo time(); ?>">
-                     </div>
+                        <input type="hidden" name="http_referer" value="<?php echo esc_url( $current_url ); ?>">
+                    </div>
 
                      <?php do_action('woocommerce_register_form'); ?>
 


### PR DESCRIPTION
## Summary
- store the current URL in the registration form
- set return URL in modal for registration and login
- redirect back to referring page if local after signup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852e68dc33483229c9b2e027578a0d1